### PR TITLE
fix build on mac

### DIFF
--- a/include/dice/hash/DiceHash.hpp
+++ b/include/dice/hash/DiceHash.hpp
@@ -356,8 +356,8 @@ namespace dice::hash {
 
     template <typename T>
     using DiceHashMartinus = DiceHash<T, Policies::Martinus>;
-    template <typename T>
-    using DiceHashxxh3 = DiceHash<T, Policies::xxh3>;
+    //template <typename T>
+    //using DiceHashxxh3 = DiceHash<T, Policies::xxh3>;
     template <typename T>
     using DiceHashwyhash = DiceHash<T, Policies::wyhash>;
 }// namespace dice::hash

--- a/include/dice/hash/DiceHash.hpp
+++ b/include/dice/hash/DiceHash.hpp
@@ -356,8 +356,10 @@ namespace dice::hash {
 
     template <typename T>
     using DiceHashMartinus = DiceHash<T, Policies::Martinus>;
-    //template <typename T>
-    //using DiceHashxxh3 = DiceHash<T, Policies::xxh3>;
+#ifdef __x86_64__
+    template <typename T>
+    using DiceHashxxh3 = DiceHash<T, Policies::xxh3>;
+#endif
     template <typename T>
     using DiceHashwyhash = DiceHash<T, Policies::wyhash>;
 }// namespace dice::hash

--- a/include/dice/hash/internal/DiceHashPolicies.hpp
+++ b/include/dice/hash/internal/DiceHashPolicies.hpp
@@ -3,7 +3,9 @@
 
 #include "martinus_robinhood_hash.hpp"
 #include "wyhash.h"
-//#include "xxhash.hpp"
+#ifdef __x86_64__
+#include "xxhash.hpp"
+#endif
 #include <type_traits>
 
 namespace dice::hash::Policies {
@@ -72,7 +74,7 @@ namespace dice::hash::Policies {
 		};
 	};
 
-#if 0
+#ifdef __x86_64__
 	struct xxh3 {
 		inline static constexpr std::size_t size_t_bits = 8 * sizeof(std::size_t);
 		inline static constexpr std::size_t seed = std::size_t(0xA24BAED4963EE407UL);

--- a/include/dice/hash/internal/DiceHashPolicies.hpp
+++ b/include/dice/hash/internal/DiceHashPolicies.hpp
@@ -3,7 +3,7 @@
 
 #include "martinus_robinhood_hash.hpp"
 #include "wyhash.h"
-#include "xxhash.hpp"
+//#include "xxhash.hpp"
 #include <type_traits>
 
 namespace dice::hash::Policies {
@@ -72,6 +72,7 @@ namespace dice::hash::Policies {
 		};
 	};
 
+#if 0
 	struct xxh3 {
 		inline static constexpr std::size_t size_t_bits = 8 * sizeof(std::size_t);
 		inline static constexpr std::size_t seed = std::size_t(0xA24BAED4963EE407UL);
@@ -109,6 +110,7 @@ namespace dice::hash::Policies {
 			}
 		};
 	};
+#endif
 
 	struct Martinus {
 		static constexpr std::size_t ErrorValue = dice::hash::martinus::seed;

--- a/tests/TestDiceHash.cpp
+++ b/tests/TestDiceHash.cpp
@@ -2,8 +2,13 @@
 
 #include <dice/hash.hpp>
 
+#ifdef __x86_64__
+#define AllPoliciesToTestForDiceHash dice::hash::Policies::Martinus, dice::hash::Policies::xxh3, \
+									 dice::hash::Policies::wyhash
+#else
 #define AllPoliciesToTestForDiceHash dice::hash::Policies::Martinus, \
 									 dice::hash::Policies::wyhash
+#endif
 #define AllTypesToTestForDiceHash int, long, std::size_t, std::byte, std::string, std::string_view, int *, long *,             \
 								  std::string *, std::unique_ptr<int>, std::shared_ptr<int>, std::vector<int>,                 \
 								  std::set<int>, std::unordered_set<int>, (std::array<int, 10>), (std::tuple<int, int, long>), \

--- a/tests/TestDiceHash.cpp
+++ b/tests/TestDiceHash.cpp
@@ -2,7 +2,7 @@
 
 #include <dice/hash.hpp>
 
-#define AllPoliciesToTestForDiceHash dice::hash::Policies::Martinus, dice::hash::Policies::xxh3, \
+#define AllPoliciesToTestForDiceHash dice::hash::Policies::Martinus, \
 									 dice::hash::Policies::wyhash
 #define AllTypesToTestForDiceHash int, long, std::size_t, std::byte, std::string, std::string_view, int *, long *,             \
 								  std::string *, std::unique_ptr<int>, std::shared_ptr<int>, std::vector<int>,                 \


### PR DESCRIPTION
- [x] conditional remove only on apple arm

POBR only changes on non x86 architectures, where it did not work at all before