### PR TITLE
Fix variant hashing and separate the error value from regular values

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Hash::is_faulty(Hash{}(your_variant));
 Every other value gets a regular hash. Types which hold nothing, like `std::monostate`,
 `std::nullopt` and empty containers, are regular values and are never reported as faulty.
 
+`ErrorValue` is a sentinel, not a value outside the range of the hash functions. A regular
+value can land on it, so `is_faulty` is a strong hint and not a proof. For unordered
+containers this is easy to trigger on purpose, because their hash is the xor of the hashes of
+their elements.
+
 ## Usage for general data hashing
 **The hash functions mentioned in this section are enabled/disabled using the feature flag `WITH_SODIUM=ON/OFF`.**
 **Enabling this flag (default behaviour) results in [libsodium](https://doc.libsodium.org/) being required as a dependency.**

--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ One simple example can be found [here](examples/customContainer.cpp).
 If you want to use `DiceHash` in a different structure (like `std::unordered_map`), you will need to set `DiceHash` as the correct template parameter.
 [This](examples/usageForUnorderedSet.cpp) is one example.
 
+### The error value
+A `std::variant` which is `valueless_by_exception` holds no alternative, so no hash can be
+calculated for it. In that case `DiceHash` returns the `ErrorValue` of the policy, which
+`is_faulty` reports:
+```c++
+using Hash = dice::hash::DiceHash<std::variant<int, std::string>>;
+Hash::is_faulty(Hash{}(your_variant));
+```
+Every other value gets a regular hash. Types which hold nothing, like `std::monostate`,
+`std::nullopt` and empty containers, are regular values and are never reported as faulty.
+
 ## Usage for general data hashing
 **The hash functions mentioned in this section are enabled/disabled using the feature flag `WITH_SODIUM=ON/OFF`.**
 **Enabling this flag (default behaviour) results in [libsodium](https://doc.libsodium.org/) being required as a dependency.**

--- a/examples/customPolicy.cpp
+++ b/examples/customPolicy.cpp
@@ -1,12 +1,15 @@
 #include <dice/hash.hpp>
 #include <initializer_list>
 #include <iostream>
+#include <limits>
 #include <numeric>
 
 
 struct MyCustomPolicy {
 	// needed for bad_variant_access
-	inline static constexpr std::size_t ErrorValue = 42;
+	// hash_bytes below returns the length, so a small number would be the hash of every
+	// buffer of that size and every such buffer would be reported as faulty
+	inline static constexpr std::size_t ErrorValue = std::numeric_limits<std::size_t>::max();
 	template<typename T>
 	static std::size_t hash_fundamental(T x) noexcept {
 		return static_cast<std::size_t>(42 * x);

--- a/include/dice/hash/DiceHash.hpp
+++ b/include/dice/hash/DiceHash.hpp
@@ -78,6 +78,13 @@ namespace dice::hash {
 		 */
 		template<typename T>
 		inline constexpr bool is_fundamental = std::is_fundamental_v<T> || std::is_same_v<std::remove_cv_t<T>, std::byte> || is_int128<T>;
+
+		/** Tags for the types which hold no value.
+		 * They are hashed with the policy, so every policy gets its own value for them.
+		 * Such a type is a regular value and must not hash to the error value of the policy.
+		 */
+		inline constexpr std::string_view monostate_tag = "dice::hash std::monostate";
+		inline constexpr std::string_view nullopt_tag = "dice::hash std::nullopt";
 	}// namespace internal
 
 	/** Class which contains all dice_hash functions.
@@ -283,25 +290,23 @@ namespace dice::hash {
 
 		/** Overload for std::monostate.
          * It is needed so its usage in std::variant is possible.
-         * Will simply return the seed.
-         * @return The seed of the hash function.
+         * @return Hash of the monostate tag.
          */
 		static std::size_t dice_hash(std::monostate const &) noexcept {
-			return Policy::ErrorValue;
+			return Policy::hash_bytes(internal::monostate_tag.data(), internal::monostate_tag.size());
 		}
 
 		/** Overload for std::nullopt_t.
-		 * Will simply return the seed.
-		 * @return The seed of the hash function.
-		 */
-		static std::size_t dice_hash([[maybe_unused]] std::nullopt_t const &) noexcept {
-			return Policy::ErrorValue;
+         * @return Hash of the nullopt tag.
+         */
+		static std::size_t dice_hash(std::nullopt_t const &) noexcept {
+			return Policy::hash_bytes(internal::nullopt_tag.data(), internal::nullopt_tag.size());
 		}
 
 		/** Implementation for optionals.
          * Hashes an index together with the contained value.
          * The index is 0 if the optional is empty and 1 if it holds a value.
-         * An empty optional uses std::monostate as its value.
+         * An empty optional uses std::nullopt as its value.
          * @tparam T Type of the optional.
          * @param opt The optional itself.
          * @return Hash value.
@@ -309,31 +314,29 @@ namespace dice::hash {
 		template<typename T>
 		static std::size_t dice_hash(std::optional<T> const &opt) noexcept {
 			if (!opt.has_value()) {
-				static constexpr size_t index = 0;
-				static constexpr std::monostate empty{};
-				return dice_hash(std::tie(index, empty));
+				static constexpr std::size_t index = 0;
+				return dice_hash(std::tie(index, std::nullopt));
 			} else {
-				static constexpr size_t index = 1;
+				static constexpr std::size_t index = 1;
 				return dice_hash(std::tie(index, *opt));
 			}
 		}
 
 		/** Implementation for variant.
-         * Will hash the value which was set.
-         * The hash of a variant of a type is equal to the hash of the type.
-         * For example: a variant of int of 42 is equal to the hash of the int of 42.
-         * If the variant is valueless_by_exception, the seed will be returned.
+         * Hashes the index of the active alternative together with its value.
+         * The index is part of the hash, so two alternatives with equal content
+         * still get different hashes.
          * @tparam VariantArgs Types of the possible values.
          * @param var The variant itself.
-         * @return Hash value.
+         * @return Hash value, the error value of the policy if the variant is valueless_by_exception.
          */
 		template<typename... VariantArgs>
 		static std::size_t dice_hash(std::variant<VariantArgs...> const &var) noexcept {
-			try {
-				return std::visit([]<typename T>(T &&arg) { return dice_hash(std::forward<T>(arg)); }, var);
-			} catch (std::bad_variant_access const &) {
+			if (var.valueless_by_exception()) {
 				return Policy::ErrorValue;
 			}
+			std::size_t const index = var.index();
+			return std::visit([&index](auto const &arg) { return dice_hash(std::tie(index, arg)); }, var);
 		}
 
 		/** Implementation for ordered container.

--- a/include/dice/hash/DiceHash.hpp
+++ b/include/dice/hash/DiceHash.hpp
@@ -79,12 +79,13 @@ namespace dice::hash {
 		template<typename T>
 		inline constexpr bool is_fundamental = std::is_fundamental_v<T> || std::is_same_v<std::remove_cv_t<T>, std::byte> || is_int128<T>;
 
-		/** Tags for the types which hold no value.
-		 * They are hashed with the policy, so every policy gets its own value for them.
-		 * Such a type is a regular value and must not hash to the error value of the policy.
+		/** Hashes of the types which hold no value.
+		 * A type which holds no value has nothing to hash, so it gets a fixed constant. The two
+		 * constants only have to be different from each other and from the error value of the
+		 * policy, which dice_hash_templates checks. They are the same for every policy.
 		 */
-		inline constexpr std::string_view monostate_tag = "dice::hash std::monostate";
-		inline constexpr std::string_view nullopt_tag = "dice::hash std::nullopt";
+		inline constexpr std::size_t monostate_hash = static_cast<std::size_t>(0x734085ee0280dfa9ull);
+		inline constexpr std::size_t nullopt_hash = static_cast<std::size_t>(0x5003c53fd5e09c85ull);
 	}// namespace internal
 
 	/** Class which contains all dice_hash functions.
@@ -92,6 +93,11 @@ namespace dice::hash {
 	 */
 	template<Policies::HashPolicy Policy>
 	class dice_hash_templates {
+		static_assert(internal::monostate_hash != Policy::ErrorValue,
+					  "the error value of the policy collides with the hash of std::monostate");
+		static_assert(internal::nullopt_hash != Policy::ErrorValue,
+					  "the error value of the policy collides with the hash of std::nullopt");
+
 	private:
 		/** Calculates the hash over an ordered container.
          * An example would be a vector, a map, an array or a list.
@@ -290,17 +296,17 @@ namespace dice::hash {
 
 		/** Overload for std::monostate.
          * It is needed so its usage in std::variant is possible.
-         * @return Hash of the monostate tag.
+         * @return The constant which stands for a value that holds nothing.
          */
 		static std::size_t dice_hash(std::monostate const &) noexcept {
-			return Policy::hash_bytes(internal::monostate_tag.data(), internal::monostate_tag.size());
+			return internal::monostate_hash;
 		}
 
 		/** Overload for std::nullopt_t.
-         * @return Hash of the nullopt tag.
+         * @return The constant which stands for a value that holds nothing.
          */
 		static std::size_t dice_hash(std::nullopt_t const &) noexcept {
-			return Policy::hash_bytes(internal::nullopt_tag.data(), internal::nullopt_tag.size());
+			return internal::nullopt_hash;
 		}
 
 		/** Implementation for optionals.

--- a/include/dice/hash/DiceHash.hpp
+++ b/include/dice/hash/DiceHash.hpp
@@ -59,10 +59,10 @@ namespace dice::hash {
 		}
 	};
 
-	/** Type traits used by dice_hash_templates.
-	 * They sit outside of the class because gcc 15 crashes with an internal compiler error
-	 * when the requires clause of a member function template uses a variable template of the
-	 * same class and that function is called with a non-dependent argument.
+	/** Type traits and constants used by dice_hash_templates.
+	 * The traits sit outside of the class because gcc 15 crashes with an internal compiler
+	 * error when the requires clause of a member function template uses a variable template
+	 * of the same class and that function is called with a non-dependent argument.
 	 */
 	namespace internal {
 #ifdef __SIZEOF_INT128__

--- a/include/dice/hash/internal/DiceHashPolicies.hpp
+++ b/include/dice/hash/internal/DiceHashPolicies.hpp
@@ -14,6 +14,10 @@
 #include "rapidhash.h"
 
 namespace dice::hash::Policies {
+    /** Requirements for a hash policy.
+     * ErrorValue signals that a hash could not be calculated. It must differ from the value the
+     * policy returns for combining nothing, otherwise an empty container looks like an error.
+     */
     template<typename T>
     concept HashPolicy =
     std::is_convertible_v<decltype(T::ErrorValue), std::size_t>
@@ -35,7 +39,7 @@ namespace dice::hash::Policies {
 				dice::hash::wyhash::_wyp[2],
 				dice::hash::wyhash::_wyp[3]
 		};
-		inline static constexpr std::size_t ErrorValue = kSeed;
+		inline static constexpr std::size_t ErrorValue = ~static_cast<std::size_t>(kSeed);
 
 		template<typename T>
 		static std::size_t hash_fundamental(T x) noexcept {
@@ -82,7 +86,7 @@ namespace dice::hash::Policies {
 	struct xxh3 {
 		inline static constexpr std::size_t size_t_bits = 8 * sizeof(std::size_t);
 		inline static constexpr std::size_t seed = std::size_t(0xA24BAED4963EE407UL);
-		inline static constexpr std::size_t ErrorValue = seed;
+		inline static constexpr std::size_t ErrorValue = ~seed;
 
 		template<typename T>
 		static std::size_t hash_fundamental(T x) noexcept {
@@ -120,7 +124,7 @@ namespace dice::hash::Policies {
 	};
 
 	struct Martinus {
-		static constexpr std::size_t ErrorValue = dice::hash::martinus::seed;
+		static constexpr std::size_t ErrorValue = ~dice::hash::martinus::seed;
 		template<typename T>
 		static std::size_t hash_fundamental(T x) noexcept {
 			if constexpr (sizeof(std::decay_t<T>) == sizeof(size_t)) {
@@ -163,7 +167,7 @@ namespace dice::hash::Policies {
 		// the value rapidhash used as its default seed up to version 1.0, where it was the
 		// macro RAPID_SEED. Version 3.0 no longer defines it.
 		inline static constexpr uint64_t kSeed = 0xbdd89aa982704029ull;
-		inline static constexpr std::size_t ErrorValue = kSeed;
+		inline static constexpr std::size_t ErrorValue = ~static_cast<std::size_t>(kSeed);
 
 		template<typename T>
 		static std::size_t hash_fundamental(T x) noexcept {

--- a/tests/TestDiceHash.cpp
+++ b/tests/TestDiceHash.cpp
@@ -20,6 +20,14 @@ namespace dice::tests::hash {
 		}
 	};
 
+	/** Second struct with the same content as UserDefinedStruct.
+	 * Both hash to the same value, so a variant of them can only be told apart by its index.
+	 */
+	struct OtherUserDefinedStruct {
+		int a;
+		OtherUserDefinedStruct(int a) : a(a) {}
+	};
+
 	struct ValuelessByException {
 		ValuelessByException() = default;
 		ValuelessByException(const ValuelessByException &) { throw std::domain_error("copy ctor"); }
@@ -169,20 +177,27 @@ namespace dice::tests::hash {
 			std::optional<std::string> example{"dog"};
 			std::string target{"dog"};
 
-			REQUIRE(getHash<CurrentPolicy>(std::make_tuple(size_t{1}, target)) == getHash<CurrentPolicy>(example));
+			REQUIRE(getHash<CurrentPolicy>(std::make_tuple(std::size_t{1}, target)) == getHash<CurrentPolicy>(example));
 		}
 
 		SECTION("(index based(0), unoccupied optional) and target generate the same hash") {
 			std::optional<std::string> example;
-			std::monostate target{};
+			std::nullopt_t target{std::nullopt};
 
-			REQUIRE(getHash<CurrentPolicy>(std::make_tuple(size_t{0}, target)) == getHash<CurrentPolicy>(example));
+			REQUIRE(getHash<CurrentPolicy>(std::make_tuple(std::size_t{0}, target)) == getHash<CurrentPolicy>(example));
 		}
 
-		SECTION("nullopt_t and monostate generate the same hash") {
+		SECTION("An unoccupied optional and a variant holding monostate don't generate the same hash") {
+			std::optional<int> example;
+			std::variant<std::monostate, int> target;
+
+			REQUIRE(getHash<CurrentPolicy>(target) != getHash<CurrentPolicy>(example));
+		}
+
+		SECTION("nullopt_t and monostate don't generate the same hash") {
 			std::nullopt_t example{std::nullopt};
 			std::monostate target{};
-			REQUIRE(getHash<CurrentPolicy>(target) == getHash<CurrentPolicy>(example));
+			REQUIRE(getHash<CurrentPolicy>(target) != getHash<CurrentPolicy>(example));
 		}
 
 		SECTION("set of optionals compiles") {
@@ -292,11 +307,35 @@ namespace dice::tests::hash {
 			std::string third = "42";
 			std::variant<int, char, std::string> test;
 			test = first;
-			REQUIRE(getHash<CurrentPolicy>(test) == getHash<CurrentPolicy>(first));
+			REQUIRE(getHash<CurrentPolicy>(test) == getHash<CurrentPolicy>(std::make_tuple(std::size_t{0}, first)));
 			test = second;
-			REQUIRE(getHash<CurrentPolicy>(test) == getHash<CurrentPolicy>(second));
+			REQUIRE(getHash<CurrentPolicy>(test) == getHash<CurrentPolicy>(std::make_tuple(std::size_t{1}, second)));
 			test = third;
-			REQUIRE(getHash<CurrentPolicy>(test) == getHash<CurrentPolicy>(third));
+			REQUIRE(getHash<CurrentPolicy>(test) == getHash<CurrentPolicy>(std::make_tuple(std::size_t{2}, third)));
+		}
+
+		SECTION("Variant and the value it holds don't generate the same hash") {
+			std::variant<int, char, std::string> test{42};
+			REQUIRE(getHash<CurrentPolicy>(test) != getHash<CurrentPolicy>(42));
+		}
+
+		SECTION("Alternatives of the same type with equal content don't generate the same hash") {
+			std::variant<long, long> first{std::in_place_index<0>, 1};
+			std::variant<long, long> second{std::in_place_index<1>, 1};
+			REQUIRE(getHash<CurrentPolicy>(first) != getHash<CurrentPolicy>(second));
+		}
+
+		SECTION("Alternatives of different types with equal content don't generate the same hash") {
+			std::variant<UserDefinedStruct, OtherUserDefinedStruct> first{UserDefinedStruct{1}};
+			std::variant<UserDefinedStruct, OtherUserDefinedStruct> second{OtherUserDefinedStruct{1}};
+			REQUIRE(getHash<CurrentPolicy>(UserDefinedStruct{1}) == getHash<CurrentPolicy>(OtherUserDefinedStruct{1}));
+			REQUIRE(getHash<CurrentPolicy>(first) != getHash<CurrentPolicy>(second));
+		}
+
+		SECTION("An unoccupied optional and a monostate in a variant don't generate the same hash") {
+			std::variant<std::optional<int>, std::monostate> first{std::in_place_index<0>, std::nullopt};
+			std::variant<std::optional<int>, std::monostate> second{std::in_place_index<1>};
+			REQUIRE(getHash<CurrentPolicy>(first) != getHash<CurrentPolicy>(second));
 		}
 
         SECTION("is_faulty returns true if ErrorValue is tested") {
@@ -307,13 +346,27 @@ namespace dice::tests::hash {
             REQUIRE(dice::hash::DiceHash<int, CurrentPolicy>::is_faulty(CurrentPolicy::ErrorValue+1) == false);
         }
 
-		SECTION("Variant monostate returns ErrorValue") {
+		SECTION("Variant monostate is not an error") {
 			std::variant<std::monostate, int, char> test;
 			auto hashed = getHash<CurrentPolicy>(test);
-            REQUIRE(dice::hash::DiceHash<decltype(test), CurrentPolicy>::is_faulty(hashed));
+            REQUIRE_FALSE(dice::hash::DiceHash<decltype(test), CurrentPolicy>::is_faulty(hashed));
 		}
 
-		SECTION("Hash of ill-formed variant is the seed") {
+		SECTION("Values which hold nothing are not errors") {
+			REQUIRE_FALSE(dice::hash::DiceHash<std::monostate, CurrentPolicy>::is_faulty(getHash<CurrentPolicy>(std::monostate{})));
+			REQUIRE_FALSE(dice::hash::DiceHash<std::nullopt_t, CurrentPolicy>::is_faulty(getHash<CurrentPolicy>(std::nullopt)));
+			REQUIRE_FALSE(dice::hash::DiceHash<std::optional<int>, CurrentPolicy>::is_faulty(getHash<CurrentPolicy>(std::optional<int>{})));
+		}
+
+		SECTION("Empty containers are not errors") {
+			REQUIRE_FALSE(dice::hash::DiceHash<std::tuple<>, CurrentPolicy>::is_faulty(getHash<CurrentPolicy>(std::tuple<>{})));
+			REQUIRE_FALSE(dice::hash::DiceHash<std::string, CurrentPolicy>::is_faulty(getHash<CurrentPolicy>(std::string{})));
+			REQUIRE_FALSE(dice::hash::DiceHash<std::vector<int>, CurrentPolicy>::is_faulty(getHash<CurrentPolicy>(std::vector<int>{})));
+			REQUIRE_FALSE(dice::hash::DiceHash<std::set<int>, CurrentPolicy>::is_faulty(getHash<CurrentPolicy>(std::set<int>{})));
+			REQUIRE_FALSE(dice::hash::DiceHash<std::map<int, int>, CurrentPolicy>::is_faulty(getHash<CurrentPolicy>(std::map<int, int>{})));
+		}
+
+		SECTION("Hash of ill-formed variant is the error value") {
 			std::variant<int, ValuelessByException> test;
 			try {
 				test = ValuelessByException();
@@ -359,12 +412,19 @@ namespace dice::tests::hash {
 * Define hash for test structures.
 */
 namespace dice::hash {
+	using dice::tests::hash::OtherUserDefinedStruct;
 	using dice::tests::hash::UserDefinedStruct;
 	using dice::tests::hash::ValuelessByException;
 
 	template<typename Policy>
 	struct dice_hash_overload<Policy, UserDefinedStruct> {
 		static std::size_t dice_hash(UserDefinedStruct const &s) noexcept {
+			return dice_hash_templates<Policy>::dice_hash(s.a);
+		}
+	};
+	template<typename Policy>
+	struct dice_hash_overload<Policy, OtherUserDefinedStruct> {
+		static std::size_t dice_hash(OtherUserDefinedStruct const &s) noexcept {
 			return dice_hash_templates<Policy>::dice_hash(s.a);
 		}
 	};


### PR DESCRIPTION
Top of the stack: `develop` <- #100 <- #94 <- this PR. Base branch is `feature/std_null_opt_hash`, so the diff only shows the work on top.

Closes #95, and addresses the variant review thread in #94.

## Variant hashing

The hash of a `std::variant` did not cover the index of the active alternative, so two
alternatives with equal content collided (issue #95). The index is now hashed together with the
value, using `std::tie` so nothing is copied. The `try`/`catch` around `std::visit` is replaced by
an explicit `valueless_by_exception()` check, which is what the exception meant anyway.

## Error state

Measured on `develop` for all four policies, before the change:

| value | Martinus | xxh3 | wyhash | rapidhash |
|---|---|---|---|---|
| `std::monostate` | = ErrorValue | = ErrorValue | = ErrorValue | = ErrorValue |
| `std::nullopt` | = ErrorValue | = ErrorValue | = ErrorValue | = ErrorValue |
| `variant<monostate, int>{}` | = ErrorValue | = ErrorValue | = ErrorValue | = ErrorValue |
| `tuple<>{}`, `set<int>{}`, `map<int,int>{}` | ok | ok | = ErrorValue | = ErrorValue |

So `is_faulty` reported plenty of perfectly regular values as faulty. Two causes:

1. `ErrorValue` was the seed of the policy, and combining nothing yields the seed. Any empty
   container hashed to the error value.
2. `monostate` and `nullopt` returned `ErrorValue` directly, although they are regular values.

Now `ErrorValue` differs from the seed, and `monostate` and `nullopt` each return a constant of
their own, the way boost.ContainerHash does it. A variant which is `valueless_by_exception` is the
only thing left that hashes to `ErrorValue`. Because the constants are known at compile time, a
`static_assert` rejects a policy whose `ErrorValue` collides with either of them.

An empty `std::optional` now uses `nullopt` instead of `monostate` as its marker. Otherwise an
empty optional and a `variant<monostate, ...>` at index 0 both hash `(0, monostate)` and collide.

For comparison, [boost.ContainerHash](https://github.com/boostorg/container_hash/blob/develop/include/boost/container_hash/hash.hpp)
hashes the variant index the same way, gives `std::monostate` a constant of its own (`0x87654321`)
and an empty optional another one (`0x12345678`). It has no error value at all: a valueless variant
hashes `variant_npos` as its index. dice-hash keeps `is_faulty`, so the sentinel stays, but it is
now reachable only from the state it describes.

## Compatibility

Hash values of variants, monostate, nullopt and optionals change. The POBR version on `develop` is
already one ahead of the released one, so it covers this change and stays as it is. `is_faulty`
keeps its signature. Custom policies keep working, they only define `ErrorValue` themselves and
nothing new is required of them.

## Tests

New sections cover the issue #95 case (same type twice, and two structs which hash equal), the
`variant<optional<int>, monostate>` case from the #94 review, and that monostate, nullopt, empty
optionals and empty containers are not reported as faulty. Existing variant sections were updated,
since a variant no longer hashes like the value it holds. Verified with gcc 15.3.1 and clang 21,
40/40 ctest green on both.


