### PR TITLE
Update rapidhash to 3.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class DiceHashConan(ConanFile):
     generators = ("CMakeDeps", "CMakeToolchain")
 
     def requirements(self):
-        self.requires("rapidhash/1.0", transitive_headers=True)
+        self.requires("rapidhash/3.0", transitive_headers=True)
         self.requires("xxhash/0.8.3", transitive_headers=True)
         if self.options.with_sodium:
             self.requires("libsodium/cci.20220430", transitive_headers=True)

--- a/include/dice/hash/internal/DiceHashPolicies.hpp
+++ b/include/dice/hash/internal/DiceHashPolicies.hpp
@@ -160,7 +160,9 @@ namespace dice::hash::Policies {
 	};
 
 	struct rapidhash {
-		inline static constexpr uint64_t kSeed = RAPID_SEED;
+		// the value rapidhash used as its default seed up to version 1.0, where it was the
+		// macro RAPID_SEED. Version 3.0 no longer defines it.
+		inline static constexpr uint64_t kSeed = 0xbdd89aa982704029ull;
 		inline static constexpr std::size_t ErrorValue = kSeed;
 
 		template<typename T>


### PR DESCRIPTION
Bottom of the current stack: `develop` <- this PR <- #94 <- #99.

Supersedes #88, which only bumps the conan requirement and therefore does not build.

## Why #88 fails

rapidhash 3.0 dropped the `RAPID_SEED` macro, so the policy no longer compiles:

```
DiceHashPolicies.hpp:163: error: 'RAPID_SEED' was not declared in this scope
```

The policy now carries that seed value itself. It is the same number rapidhash 1.0 defined, so
the seed of the policy does not change.

## Hash values change

rapidhash 3.0 is a different algorithm, not just a repackaging. Same input, same seed:

| input | rapidhash 1.0 | rapidhash 3.0 |
|---|---|---|
| `"hello world"` | `f2d71876bf6d2e13` | `85d7a9bb1eade1ba` |
| `int 42` | `e30b62bd2e12c692` | `a50a7b60ed9ba947` |

Anything persisted with the rapidhash policy has to be rehashed.

Worth knowing: **the abi-diff check does not catch this.** It watches headers under
`include/dice/hash/internal`, `include/dice/hash/blake` and `include/dice/hash/lthash`, but
`rapidhash.h` comes from the conan package. On #88, which changes nothing but `conanfile.py`,
the check passes while every rapidhash value silently changes. The POBR version on `develop` is
already one ahead of the released one, so it covers this change and stays as it is.

## Tests

Built and ran the suite against rapidhash 3.0 with gcc 15.3.1 and clang 21, all green.
